### PR TITLE
ci: fix missing environment var in scheduled builds

### DIFF
--- a/.github/workflows/schedule-trigger.yml
+++ b/.github/workflows/schedule-trigger.yml
@@ -61,7 +61,7 @@ jobs:
         shell: bash
         #language=bash
         run: |
-          gh workflow run --repo "$REPOSITORY" "$WORKFLOW_NAME.yml"
+          gh workflow run "$WORKFLOW_NAME.yml"
 
           echo "Job '$WORKFLOW_NAME' dispatched."
 


### PR DESCRIPTION
remove reference to a removed environment variable. as the workflow runs on the current repo, it shouldn't be needed.

Bug introduced [here](https://github.com/myparcelnl/docker-images/commit/0ebd4512bb7c790cb063232d6db2e165f99072c0#diff-bf41f55948e8fadb2563a2d817699635bf31cc0947883ebf8499b11ea3e02786L55)

Alternatively we can restore this variable, but it doesn't seem to be needed as far as I can determine.