### PR TITLE
build: fix broken plugin builds due to missing -fpm images

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ docker compose build
 
 [View on GitHub Container Registry 📦](https://ghcr.io/myparcelnl/php-xd)
 
-PHP images based on `php:<version>-alpine`, with Composer 2.5 and XDebug.
+PHP images based on `php:<version>-fpm-alpine`, with Composer 2.5 and pcov installed, and XDebug enabled. Based on the fpm variant of the official PHP images, so you can use it for both CLI and web applications.
 
 ### PHP versions
 

--- a/images/php-xd/Dockerfile
+++ b/images/php-xd/Dockerfile
@@ -1,9 +1,9 @@
 ARG PHP_VERSION="7.2"
 ARG ALPINE_VERSION=""
 
-FROM php:${PHP_VERSION}-alpine${ALPINE_VERSION} AS base
+FROM php:${PHP_VERSION}-fpm-alpine${ALPINE_VERSION} AS base
 
-LABEL org.opencontainers.image.description='Alpine image with php, composer 2, XDebug and pcov.'
+LABEL org.opencontainers.image.description='Alpine image with php-fpm, composer 2, XDebug and pcov.'
 
 RUN if [ $(php -r "echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;") = "71" ]; then \
         export COMPOSER_VERSION="2.2.0"; \

--- a/images/prestashop/Dockerfile
+++ b/images/prestashop/Dockerfile
@@ -11,7 +11,7 @@ FROM ghcr.io/myparcelnl/node:${NODE_VERSION}-yarn${YARN_VERSION} AS node
 ##########
 # Prestashop
 ##########
-FROM ghcr.io/myparcelnl/php-xd:${PHP_VERSION}-fpm-alpine AS prestashop
+FROM ghcr.io/myparcelnl/php-xd:${PHP_VERSION}-alpine AS prestashop
 
 ENV YARN_IGNORE_NODE=1
 

--- a/images/shopware/Dockerfile
+++ b/images/shopware/Dockerfile
@@ -3,7 +3,7 @@ ARG PHP_VERSION="8.1"
 ##########
 # Shopware
 ##########
-FROM ghcr.io/myparcelnl/php-xd:${PHP_VERSION}-fpm-alpine AS shopware
+FROM ghcr.io/myparcelnl/php-xd:${PHP_VERSION}-alpine AS shopware
 
 ARG NODE_VERSION="16"
 ARG SW_VERSION="6.5.0.0"

--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -3,7 +3,7 @@ ARG PHP_VERSION="7.4"
 ##########
 # WordPress
 ##########
-FROM ghcr.io/myparcelnl/php-xd:${PHP_VERSION}-fpm-alpine AS wordpress
+FROM ghcr.io/myparcelnl/php-xd:${PHP_VERSION}-alpine AS wordpress
 
 ARG WP_VERSION="6.1.1"
 


### PR DESCRIPTION
modifies the built php-xd images to be based off of php-fpm rather than php-cli. this way, we no longer need to build separate images for cli and web usage.